### PR TITLE
build: split install and install-data targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ VARDIR ?= /var/
 all:
 	cargo build --release
 
-install:
+install: install-data
 	install -dDm0755 $(DESTDIR)/$(BINDIR)
 	install -pm0755 target/release/speakersafetyd $(DESTDIR)/$(BINDIR)/speakersafetyd
+
+install-data:
 	install -dDm0755 $(DESTDIR)/$(UNITDIR)
 	install -pm0644 speakersafetyd.service $(DESTDIR)/$(UNITDIR)/speakersafetyd.service
 	install -dDm0755 $(DESTDIR)/$(UDEVDIR)
@@ -24,3 +26,5 @@ install:
 uninstall:
 	rm -f $(DESTDIR)/$(BINDIR)/speakersafetyd $(DESTDIR)/$(UNITDIR)/speakersafetyd.service $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules
 	rm -rf $(DESTDIR)/$(SHAREDIR)/speakersafetyd
+
+.PHONY: all install install-data uninstall


### PR DESCRIPTION
This allows only installing the data files in case the build is done separately (like for example when using debcargo/dh-cargo which uses rustc --target option and thus the speakersafetyd ends up in a different path which includes the target).

While at it also mark all targets as PHONY, since none of them are backed by an actual file with the same name.