### PR TITLE
Fix tas2764 volume control name

### DIFF
--- a/conf/apple/j375.conf
+++ b/conf/apple/j375.conf
@@ -1,1 +1,31 @@
-j274.conf
+[Globals]
+visense_pcm = 2
+t_ambient = 46.0
+t_hysteresis = 5.0
+t_window = 20.0
+channels = 2
+period = 4096
+link_gains = False
+uclamp_max = 64
+
+[Controls]
+vsense = VSENSE Switch
+isense = ISENSE Switch
+amp_gain = Amp Gain Volume
+volume = Speaker Volume
+
+[Speaker/Mono]
+group = 0
+tr_coil = 40.00
+tr_magnet = 60.00
+tau_coil = 3.70
+tau_magnet = 250.00
+t_limit = 140.0
+t_headroom = 40.0
+z_nominal = 4.60
+a_t_20c = 0.0037
+a_t_35c = 0.0037
+is_scale = 3.75
+vs_scale = 14
+is_chan = 0
+vs_chan = 1

--- a/conf/apple/j473.conf
+++ b/conf/apple/j473.conf
@@ -1,1 +1,1 @@
-j274.conf
+j375.conf

--- a/conf/apple/j474.conf
+++ b/conf/apple/j474.conf
@@ -1,1 +1,1 @@
-j274.conf
+j375.conf

--- a/conf/apple/j475.conf
+++ b/conf/apple/j475.conf
@@ -1,1 +1,1 @@
-j274.conf
+j375.conf

--- a/conf/apple/j493.conf
+++ b/conf/apple/j493.conf
@@ -1,1 +1,79 @@
-j293.conf
+[Globals]
+visense_pcm = 2
+t_ambient = 50.0
+t_hysteresis = 5.0
+t_window = 20.0
+channels = 8
+period = 4096
+link_gains = True
+uclamp_max = 64
+
+[Controls]
+vsense = VSENSE Switch
+isense = ISENSE Switch
+amp_gain = Amp Gain Volume
+volume = Speaker Volume
+
+[Speaker/Left Front]
+group = 0
+tr_coil = 38.30
+tr_magnet = 49.10
+tau_coil = 2.80
+tau_magnet = 79.70
+t_limit = 130.0
+t_headroom = 10.0
+z_nominal = 9.70
+a_t_20c = 0.0037
+a_t_35c = 0.0037
+is_scale = 3.75
+vs_scale = 14
+is_chan = 0
+vs_chan = 1
+
+[Speaker/Right Front]
+group = 0
+tr_coil = 38.30
+tr_magnet = 49.10
+tau_coil = 2.80
+tau_magnet = 79.70
+t_limit = 130.0
+t_headroom = 10.0
+z_nominal = 9.70
+a_t_20c = 0.0037
+a_t_35c = 0.0037
+is_scale = 3.75
+vs_scale = 14
+is_chan = 2
+vs_chan = 3
+
+[Speaker/Left Rear]
+group = 0
+tr_coil = 38.30
+tr_magnet = 49.10
+tau_coil = 2.80
+tau_magnet = 79.70
+t_limit = 130.0
+t_headroom = 10.0
+z_nominal = 9.70
+a_t_20c = 0.0037
+a_t_35c = 0.0037
+is_scale = 3.75
+vs_scale = 14
+is_chan = 4
+vs_chan = 5
+
+[Speaker/Right Rear]
+group = 0
+tr_coil = 38.30
+tr_magnet = 49.10
+tau_coil = 2.80
+tau_magnet = 79.70
+t_limit = 130.0
+t_headroom = 10.0
+z_nominal = 9.70
+a_t_20c = 0.0037
+a_t_35c = 0.0037
+is_scale = 3.75
+vs_scale = 14
+is_chan = 6
+vs_chan = 7


### PR DESCRIPTION
j375, j473, j474, j475 and j493 omit `Playback` from their volume control name. Fix the configs accordingly.