### PR TITLE
Fix blackbox path in Makefile install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 BINDIR ?= /usr/bin
 UNITDIR ?= /lib/systemd/system
 UDEVDIR ?= /lib/udev/rules.d
+TMPFILESDIR ?= /usr/lib/tmpfiles.d
 SHAREDIR ?= /usr/share/
 VARDIR ?= /var/
 
@@ -20,7 +21,9 @@ install:
 	install -dDm0755 $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple
 	install -pm0644 -t $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple $(wildcard conf/apple/*)
 	install -dDm0755 $(DESTDIR)/$(VARDIR)/lib/speakersafetyd/blackbox
+	install -dDm0755 $(DESTDIR)/$(TMPFILESDIR)
+	install -pm0644 speakersafetyd.tmpfiles $(DESTDIR)/$(TMPFILESDIR)/speakersafetyd.conf
 
 uninstall:
-	rm -f $(DESTDIR)/$(BINDIR)/speakersafetyd $(DESTDIR)/$(UNITDIR)/speakersafetyd.service $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules
+	rm -f $(DESTDIR)/$(BINDIR)/speakersafetyd $(DESTDIR)/$(UNITDIR)/speakersafetyd.service $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules $(DESTDIR)/$(TMPFILESDIR)/speakersafetyd.conf
 	rm -rf $(DESTDIR)/$(SHAREDIR)/speakersafetyd

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install:
 	install -pm0644 95-speakersafetyd.rules $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules
 	install -dDm0755 $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple
 	install -pm0644 -t $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple $(wildcard conf/apple/*)
-	install -dDm0755 $(DESTDIR)/$(VARDIR)/speakersafetyd/blackbox
+	install -dDm0755 $(DESTDIR)/$(VARDIR)/lib/speakersafetyd/blackbox
 
 uninstall:
 	rm -f $(DESTDIR)/$(BINDIR)/speakersafetyd $(DESTDIR)/$(UNITDIR)/speakersafetyd.service $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules

--- a/speakersafetyd.tmpfiles
+++ b/speakersafetyd.tmpfiles
@@ -1,0 +1,1 @@
+d /var/lib/speakersafetyd/blackbox 0755 root root -


### PR DESCRIPTION
The Makefile has a typo so that it creates the blackbox directory under `/var/speakersafetyd/...` instead of `/var/lib/speakersafetyd/...`.
The former is not FHS compliant according to lintian (debian lint tool) and is obviously a typo since the speakersafetyd.service file also spells out the full blackbox path and uses the latter.

This MR includes a commit fixing the Makefile and then a bonus commit that adds a tmpfiles.d snippet that (re)creates the blackbox directory when/if needed since it's living under `/var`.