### PR TITLE
Align debug prints

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -396,7 +396,7 @@ impl Speaker {
         }
 
         debug!(
-            "{}: Coil {:.2} °C Magnet {:.2} °C Power {:.2} W Gain {:.2} dB",
+            "{:>15}: Coil {:>6.2} °C Magnet {:>6.2} °C Power {:>5.2} W Gain {:>6.2} dB",
             self.name, s.t_coil, s.t_magnet, pwr_avg, s.gain
         );
 


### PR DESCRIPTION
Previously, debug!() prints of speaker name, temperatures, power and gain were jumping from left to right, now they are aligned.

Before:

![Screenshot before](https://github.com/AsahiLinux/speakersafetyd/assets/71599788/b83c33d3-9480-46a7-90ac-1916a6fb206d)

After:


![Screenshot after](https://github.com/AsahiLinux/speakersafetyd/assets/71599788/12297037-3234-4cc9-91f0-dec61de57ae9)

(Gain align should be checked in screenshot below)

With random values:

<img width="629" alt="Screenshot with random values" src="https://github.com/AsahiLinux/speakersafetyd/assets/71599788/ba626967-42dc-4e64-826b-5220540a6bf6">
