### PR TITLE
Support not running as root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ UDEVDIR ?= /lib/udev/rules.d
 TMPFILESDIR ?= /usr/lib/tmpfiles.d
 SHAREDIR ?= /usr/share/
 VARDIR ?= /var/
+SPEAKERSAFETYD_GROUP ?= speakersafetyd
+SPEAKERSAFETYD_USER ?= speakersafetyd
 
 all:
 	cargo build --release
@@ -22,9 +24,10 @@ install-data:
 	install -pm0644 95-speakersafetyd.rules $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules
 	install -dDm0755 $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple
 	install -pm0644 -t $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple $(wildcard conf/apple/*)
-	install -dDm0755 $(DESTDIR)/$(VARDIR)/lib/speakersafetyd/blackbox
+	install -dDm0755 -o $(SPEAKERSAFETYD_USER) -g $(SPEAKERSAFETYD_GROUP) $(DESTDIR)/$(VARDIR)/lib/speakersafetyd/blackbox
 	install -dDm0755 $(DESTDIR)/$(TMPFILESDIR)
 	install -pm0644 speakersafetyd.tmpfiles $(DESTDIR)/$(TMPFILESDIR)/speakersafetyd.conf
+	install -dDm0755 -o $(SPEAKERSAFETYD_USER) -g $(SPEAKERSAFETYD_GROUP) /run/speakersafetyd
 
 uninstall:
 	rm -f $(DESTDIR)/$(BINDIR)/speakersafetyd $(DESTDIR)/$(UNITDIR)/speakersafetyd.service $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules $(DESTDIR)/$(TMPFILESDIR)/speakersafetyd.conf

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ adapt for any device that provides V/ISENSE data in a manner similar to TAS2764.
 * Rust stable
 * alsa-lib
 * An Apple Silicon Mac running Asahi Linux
+* A `speakersafetyd` user in the `audio` group
 
 ### Some background on Smart Amps
 The cheap component speaker elements used in modern devices like

--- a/speakersafetyd.service
+++ b/speakersafetyd.service
@@ -4,6 +4,9 @@ Description=Speaker Protection Daemon
 [Service]
 Type=simple
 ExecStart=/usr/bin/speakersafetyd -c /usr/share/speakersafetyd/ -b /var/lib/speakersafetyd/blackbox -m 7
+User=speakersafetyd
+AmbientCapabilities=CAP_SYS_NICE
+CapabilityBoundingSet=CAP_SYS_NICE
 UMask=0066
 Restart=on-failure
 RestartSec=1

--- a/speakersafetyd.tmpfiles
+++ b/speakersafetyd.tmpfiles
@@ -1,1 +1,2 @@
-d /var/lib/speakersafetyd/blackbox 0755 root root -
+d /var/lib/speakersafetyd/blackbox 0755 speakersafetyd speakersafetyd -
+d /run/speakersafetyd 0755 speakersafetyd speakersafetyd -

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ const DEFAULT_CONFIG_PATH: &str = "share/speakersafetyd";
 
 const UNLOCK_MAGIC: i32 = 0xdec1be15u32 as i32;
 
-const FLAGFILE: &str = "/run/speakersafetyd.flag";
+const FLAGFILE: &str = "/run/speakersafetyd/speakersafetyd.flag";
 
 /// Simple program to greet a person
 #[derive(Parser, Debug)]


### PR DESCRIPTION
We don't need to be running as root. Let's run as speakersafetyd by default.