### PR TITLE
Use systemd for runtime/statedirectories and dynamic users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,8 @@
 BINDIR ?= /usr/bin
 UNITDIR ?= /lib/systemd/system
 UDEVDIR ?= /lib/udev/rules.d
-TMPFILESDIR ?= /usr/lib/tmpfiles.d
 SHAREDIR ?= /usr/share/
 VARDIR ?= /var/
-SPEAKERSAFETYD_GROUP ?= speakersafetyd
-SPEAKERSAFETYD_USER ?= speakersafetyd
 
 all:
 	cargo build --release
@@ -24,14 +21,9 @@ install-data:
 	install -pm0644 95-speakersafetyd.rules $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules
 	install -dDm0755 $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple
 	install -pm0644 -t $(DESTDIR)/$(SHAREDIR)/speakersafetyd/apple $(wildcard conf/apple/*)
-	install -dDm0755 -o $(SPEAKERSAFETYD_USER) -g $(SPEAKERSAFETYD_GROUP) $(DESTDIR)/$(VARDIR)/lib/speakersafetyd
-	install -dDm0700 -o $(SPEAKERSAFETYD_USER) -g $(SPEAKERSAFETYD_GROUP) $(DESTDIR)/$(VARDIR)/lib/speakersafetyd/blackbox
-	install -dDm0755 $(DESTDIR)/$(TMPFILESDIR)
-	install -pm0644 speakersafetyd.tmpfiles $(DESTDIR)/$(TMPFILESDIR)/speakersafetyd.conf
-	install -dDm0755 -o $(SPEAKERSAFETYD_USER) -g $(SPEAKERSAFETYD_GROUP) $(DESTDIR)/run/speakersafetyd
 
 uninstall:
-	rm -f $(DESTDIR)/$(BINDIR)/speakersafetyd $(DESTDIR)/$(UNITDIR)/speakersafetyd.service $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules $(DESTDIR)/$(TMPFILESDIR)/speakersafetyd.conf
+	rm -f $(DESTDIR)/$(BINDIR)/speakersafetyd $(DESTDIR)/$(UNITDIR)/speakersafetyd.service $(DESTDIR)/$(UDEVDIR)/95-speakersafetyd.rules
 	rm -rf $(DESTDIR)/$(SHAREDIR)/speakersafetyd
 
 .PHONY: all install install-data uninstall

--- a/speakersafetyd.service
+++ b/speakersafetyd.service
@@ -4,7 +4,12 @@ Description=Speaker Protection Daemon
 [Service]
 Type=simple
 ExecStart=/usr/bin/speakersafetyd -c /usr/share/speakersafetyd/ -b /var/lib/speakersafetyd/blackbox -m 7
+RuntimeDirectory=speakersafetyd
+StateDirectory=speakersafetyd
+DynamicUser=true
 User=speakersafetyd
+Group=speakersafetyd
+SupplementaryGroups=audio
 AmbientCapabilities=CAP_SYS_NICE
 CapabilityBoundingSet=CAP_SYS_NICE
 UMask=0066

--- a/speakersafetyd.tmpfiles
+++ b/speakersafetyd.tmpfiles
@@ -1,3 +1,0 @@
-d /var/lib/speakersafetyd 755 speakersafetyd speakersafetyd -
-d /var/lib/speakersafetyd/blackbox 0700 speakersafetyd speakersafetyd -
-d /run/speakersafetyd 0755 speakersafetyd speakersafetyd -

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 */
 use std::collections::BTreeMap;
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -151,6 +152,8 @@ fn main() {
 
     let mut blackbox = args.blackbox_path.map(|p| {
         info!("Enabling blackbox, path: {:?}", p);
+        std::fs::create_dir_all(&p).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o700)).unwrap();
         blackbox::Blackbox::new(&machine, &p, &globals)
     });
 


### PR DESCRIPTION
In systemd units, we can use RuntimeDirectory= and StateDirectory= to create /run/speakersafetyd and /var/lib/speakersafetyd, and have it be owned by the user running the service automatically.

This makes permission management less brittle than having the `make install` phase or systemd-tmpfiles take care of applying ownership.

Some build sandboxes (like the NixOS one) don't propagate users defined on the global system, but provide a almost-empty `/etc/passwd` and `/etc/group`, so `install -o $user -g $group` cannot look up a user that's not available in the sandbox.

In fact, setting up the global user is not required at all, we can dynamically [allocate a user on-demand][0pointer-dynamic-users], which also brings some more sandboxing and isolation.

Creating the `blackbox` subdirectory inside the state directory and setting up more restrictive permissions is left to the process itself. Theoretically, we could just be more restrictive on the state directory itself, and use StateDirectoryMode=, though I wanted to keep the existing behaviour for now.

![image](https://github.com/user-attachments/assets/d776c84d-2078-472d-845d-5abe3bdc4b4f)


Closes #25.

[0pointer-dynamic-users]: https://0pointer.net/blog/dynamic-users-with-systemd.html